### PR TITLE
Escaping the query value to prevent XSS attacks

### DIFF
--- a/client/jsx/lib/search.jsx
+++ b/client/jsx/lib/search.jsx
@@ -229,7 +229,7 @@ function searchCallback(data, textStatus) {
 
     if (data.length > 0) {
 
-	$('#txt_subtitle').html(data[0]);
+	$('#txt_subtitle').html(escape(data[0]));
 	
 	$('#txt_list').html(data[1]);
 


### PR DESCRIPTION
There are two options to prevent XSS attacks in this case, we can either escape the search before we send it to the Backend or we escape data[0] as it comes back in the callback without any treatment. 

I chose for the 2nd option so we don't interfere in the language accepted by our search engine.