### PR TITLE
bower issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ SGDBackend, then creates the pages of the website.
 
 Prerequisities, node.js > 4.2.0 and python 2.7.x. o manage python dependencies, configure a virtualenv for this project. See [virtualenv guide](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 
+
+### Node packages issues and versions
+You may run into issues with node version. Currently the build is using Node v6.10.2. Make sure you're on this version. We're working migrate packages management to yarn and webpack so all these legacy version issues might be resolved once we make that switch. See requirements below:
+
+1. Ruby version, point to ruby-2.3
+2. Node version, point to v6.10.2
+3. Bower version, point to v1.8.4(latest). Run the following commands:
+        $ npm install -g bower
+        $ bower install
+
+
 To build the application and install dependencies.
 
     $ make build
@@ -76,3 +87,8 @@ First, download ngrok (add URL) and start your ngrok server [https://ngrok.com/d
 Then, run
 
     $ make ghost-local
+
+
+
+
+```

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "modernizr": "2.8.3",
     "nouislider": "6.2.0",
     "rem-unit-polyfill": "1.3.2",
-    "respond": ">=1.4.2"
+    "respond": ">=1.4.2",
+    "font-awesome": "4.6.0"
   },
   "resolutions": {
     "jquery": "^1.11.1"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
-    "bower": "~1.3.3",
+    "bower": "~1.8.4",
     "envify": "^4.0.0",
     "fastclick": "~1.0.3",
     "grunt": "~0.4.5",


### PR DESCRIPTION

Bower issue fix. Bower moved from hosting on heroku to https://registry.bower.io so any old bower package, 1.8.0 in our case, fetches from deprecated resource(https://bower.herokuapp.com) thereby causing the build issue when the repo is cloned. 
--
ps: https://redmine.yeastgenome.org/issues/5196