### PR TITLE
20.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ production_asset_url.json
 *py_cache*
 .pytest*
 Notes.MD
+prod_deploy_variables_old.sh

--- a/client/jsx/components/sequence/multi_sequence_download.jsx
+++ b/client/jsx/components/sequence/multi_sequence_download.jsx
@@ -41,7 +41,7 @@ var MultiSequenceDownload = React.createClass({
 			};
 			return <li key={"seqButton" + i}><a onClick={_onClick}>{s.name}</a></li>;
 		});
-		buttonNodes.push(<li key="topSeqButton"><a href={"/cgi-bin/seqTools?back=1&seqname=" + this.props.locusFormatName}>Custom Retrieval</a></li>);
+		buttonNodes.push(<li key="topSeqButton"><a href={"/seqTools?seqname=" + this.props.locusFormatName}>Custom Retrieval</a></li>);
 
 		var hiddenFormContainerNode = (<div style={{ display: "none" }}>
 			{_hiddenFormNodes}

--- a/client/jsx/components/viz/expression_chart.jsx
+++ b/client/jsx/components/viz/expression_chart.jsx
@@ -27,11 +27,11 @@ var ExpressionChart = React.createClass({
 
 	getDefaultProps: function () {
 		return {
-			data: null,
+			data: {},
 			hasHelpIcon: false,
 			hasScaleToggler: false,
-			minValue: null,
-			maxValue: null,
+			minValue: 0,
+			maxValue: 0,
 			onClick: null // (min, max) =>
 		};
 	},

--- a/client/jsx/containers/layout/header.jsx
+++ b/client/jsx/containers/layout/header.jsx
@@ -16,7 +16,8 @@ const Header = React.createClass({
             <div className="site-links">
               <a target="_blank" href="https://sites.google.com/view/yeastgenome-help/about" className="hide-external-link-icon">About</a>
               <a href="/blog">Blog</a>
-              <a href="https://downloads.yeastgenome.org">Download</a>
+              <a href="http://sgd-archive.yeastgenome.org">Download</a>
+	      <a href="https://www.yeastgenome.org/search?q=&is_quick=true">Explore</a>
               <a className="hide-external-link-icon" target="_blank" href="https://sites.google.com/view/yeastgenome-help/">Help</a>
               <a href="https://yeastmine.yeastgenome.org/yeastmine/begin.do">YeastMine</a>
               <div className="social-media-links">

--- a/client/scss/modules/_header.scss
+++ b/client/scss/modules/_header.scss
@@ -11,7 +11,7 @@ $logo-height: 40px;
 $top-header-text-font-size: 14px;
 $header-text-font-size: 14px;
 $search-width: 224px;
-$large-search-width : 390px;
+$large-search-width : 440px;
 $top-header-font-color: #CCC;
 
 .top-header {

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ zope.deprecation==4.1.2
 zope.interface==4.1.3
 nose==1.3.7
 python-dateutil==2.6.0
+Paste==3.4.0

--- a/sgdfrontend_production.ini
+++ b/sgdfrontend_production.ini
@@ -3,7 +3,7 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
 ###
 
-[app:main]
+[app:wsgiapp]
 use = egg:SGDFrontend#yeastgenome
 
 pyramid.reload_templates = false
@@ -30,10 +30,10 @@ backlog = 8192
 ###
 
 [loggers]
-keys = root, yeastgenome
+keys = root, yeastgenome, wsgiapp
 
 [handlers]
-keys = console, filelog
+keys = console, filelog, trafficlog
 
 [formatters]
 keys = generic
@@ -47,6 +47,11 @@ level = WARN
 handlers =
 qualname = yeastgenome
 
+[logger_wsgiapp]
+level = INFO
+handlers = trafficlog
+qualname = wsgi
+
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
@@ -59,5 +64,19 @@ args = ('/data/www/logs/frontend.log','a')
 level = INFO
 formatter = generic
 
+[handler_trafficlog]
+class = FileHandler
+args = ('/data/www/logs/traffic.log','a')
+level = INFO
+formatter = 
+
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+[filter:translogger]
+use = egg:Paste#translogger
+setup_console_handler = False
+
+[pipeline:main]
+pipeline = translogger
+           wsgiapp

--- a/src/sgd/frontend/yeastgenome/static/js/go_details.js
+++ b/src/sgd/frontend/yeastgenome/static/js/go_details.js
@@ -143,7 +143,7 @@ var graph_style = cytoscape.stylesheet()
 	.css({
 		'width': 2
 	})
-	.selector("node[sub_type='FOCUS']")
+	.selector("node[category='FOCUS']")
 	.css({
 		'background-color': "#fade71",
 		'text-outline-color': '#fff',

--- a/src/sgd/frontend/yeastgenome/static/js/regulation_overview.js
+++ b/src/sgd/frontend/yeastgenome/static/js/regulation_overview.js
@@ -38,7 +38,7 @@ if(locus['regulation_overview']['target_count'] + locus['regulation_overview']['
         google.visualization.events.addListener(chart, 'select', barSelectHandler);
 
         chart.draw(data_table, {
-            'title': 'Transcriptional Targets and Regulators for ' + locus['display_name'] + ' (includes high-throughput predictions)',
+            'title': 'Targets and Regulators for ' + locus['display_name'] + ' (includes high-throughput predictions)',
             'legend': {'position': 'none'},
             'hAxis': {title: 'Genes', minValue:0, maxValue:5, gridlines:{count:6}},
             'dataOpacity':1,

--- a/src/sgd/frontend/yeastgenome/static/templates/disease_details.jinja2
+++ b/src/sgd/frontend/yeastgenome/static/templates/disease_details.jinja2
@@ -147,8 +147,8 @@
             <a href="#" data-dropdown="network_info"><i class="fa fa-info-circle"></i></a>
 
             <p id="network_info" class="f-dropdown content medium" data-dropdown-content>
-                This diagram displays manually curated and high-throughput DO terms (orange circles) that are shared between the given gene (black circle) and yeast genes (dark blue
-                circles).
+                This diagram displays manually curated and high-throughput DO terms (orange circles) that are shared between the given gene (black 
+                circle), other yeast genes (dark blue circles), and human genes (light blue circles).
             </p>
         </h2>
         <hr />

--- a/src/sgd/frontend/yeastgenome/static/templates/header.jinja2
+++ b/src/sgd/frontend/yeastgenome/static/templates/header.jinja2
@@ -11,7 +11,7 @@
               <span class="sgd-announcment"></span>
             </div>
             <div class="site-links">
-                <a target="_blank" href="https://sites.google.com/view/yeastgenome-help/about" class="hide-external-link-icon">About</a><a href="/blog">Blog</a><a href="/downloads">Download</a><a class="hide-external-link-icon" target="_blank" href="https://sites.google.com/view/yeastgenome-help">Help</a><a href="http://yeastmine.yeastgenome.org/yeastmine/begin.do">YeastMine</a>
+                <a target="_blank" href="https://sites.google.com/view/yeastgenome-help/about" class="hide-external-link-icon">About</a><a href="/blog">Blog</a><a href="http://sgd-archive.yeastgenome.org">Download</a><a href="https://www.yeastgenome.org/search?q=&is_quick=true">Explore</a><a class="hide-external-link-icon" target="_blank" href="https://sites.google.com/view/yeastgenome-help">Help</a><a href="http://yeastmine.yeastgenome.org/yeastmine/begin.do">YeastMine</a>
                 <div class="social-media-links">
                     <a href="mailto:sgd-helpdesk@lists.stanford.edu" id="email-header" class="webicon mail small">Email Us</a><a href="http://twitter.com/#!/yeastgenome" target="_blank" id="twitter" class="webicon twitter small">Twitter</a><a href="https://www.facebook.com/yeastgenome" target="_blank" class="webicon facebook small" id="facebook">Facebook</a><a href="https://www.linkedin.com/company/saccharomyces-genome-database" target="_blank" class="webicon linkedin small" id="linkedin">Linkedin</a><a href="https://www.youtube.com/SaccharomycesGenomeDatabase" target="_blank" id="youtube" class="webicon youtube small">YouTube</a>
                 </div>

--- a/src/sgd/frontend/yeastgenome/static/templates/header.jinja2
+++ b/src/sgd/frontend/yeastgenome/static/templates/header.jinja2
@@ -64,7 +64,7 @@
                     </li>
                     <li class="has-dropdown"><a href="#">Sequence</a>
                         <ul class="dropdown">
-                            <li><a class="disabled-header-a" href="https://downloads.yeastgenome.org/sequence">Download</a>
+                            <li><a class="disabled-header-a" href="http://sgd-archive.yeastgenome.org/sequence/">Download</a>
                             </li>
                             <li><a class="disabled-header-a" href="https://browse.yeastgenome.org">Genome Browser</a>
                             </li>
@@ -76,7 +76,7 @@
                             </li>
                             <li class="has-dropdown"><a href="#">Reference Genome</a>
                                 <ul class="dropdown">
-                                    <li><a class="disabled-header-a" href="http://downloads.yeastgenome.org/sequence/S288C_reference/genome_releases/">Download Genome</a>
+                                    <li><a class="disabled-header-a" href="http://sgd-archive.yeastgenome.org/sequence/S288C_reference/genome_releases/">Download Genome</a>
                                     </li>
                                     <li><a class="disabled-header-a" href="/genomesnapshot">Genome Snapshot</a>
                                     </li>
@@ -117,7 +117,7 @@
                                     </li>
                                     <li><a class="disabled-header-a" href="/goSlimMapper">GO Slim Mapper</a>
                                     </li>
-                                    <li><a class="disabled-header-a" href="http://downloads.yeastgenome.org/curation/literature/go_slim_mapping.tab">GO Slim Mapping File</a>
+                                    <li><a class="disabled-header-a" href="http://sgd-archive.yeastgenome.org/curation/literature/go_slim_mapping.tab">GO Slim Mapping File</a>
                                     </li>
                                 </ul>
                             </li>

--- a/src/sgd/frontend/yeastgenome/static/templates/homepage.jinja2
+++ b/src/sgd/frontend/yeastgenome/static/templates/homepage.jinja2
@@ -156,7 +156,7 @@ anti-Fpr3 antibody courtesy of Jeremy Thorner, Ph.D., UC Berkeley</span>
             <h2>About SGD</h2>
             <p>The <em>Saccharomyces</em> Genome Database (SGD) provides comprehensive integrated biological information for the budding yeast <em>Saccharomyces cerevisiae</em> along with search and analysis tools to explore these data, enabling the discovery of functional relationships between sequence and gene products in fungi and higher organisms.</p>
             <div class="text-center">
-                <a class="button large explore-btn" href="/search" id="j-try-btn">Try this?</i></a>
+                <a class="button large explore-btn" href="/search?q=&is_quick=true" id="j-try-btn">Explore SGD</i></a>
             </div>
         </div>
     </div>
@@ -205,26 +205,5 @@ anti-Fpr3 antibody courtesy of Jeremy Thorner, Ph.D., UC Berkeley</span>
     setTimeout(function () {
         $('#slide-show').css({ visibility: 'visible' });
     }, 300);
-    // randomize "try this"
-    var queryUrls = [
-        '/search?q=polymerase',
-        '/search?q=cell%20cycle',
-        '/search?q=nuclear',
-        '/search?q=phosphate',
-        '/search?q=ethanol',
-        '/search?q=oxidative',
-        '/search?q=disease',
-        '/search?q=homolog',
-        '/search?q=mitochondrial',
-        '/search?q=vacuolar',
-        '/search?q=cholesterol',
-        '/search?q=BLAST',
-        '/search?q=pathogen',
-        '/search?q=helicase',
-        '/search?q=G-protein',
-        '/search?q=anaerobic'
-    ];
-    var randomQueryUrl = queryUrls[Math.floor(queryUrls.length * Math.random())];
-    document.getElementById('j-try-btn').href = randomQueryUrl;
 </script>
 {% endblock scripts %}

--- a/src/sgd/frontend/yeastgenome/static/templates/literature_details.jinja2
+++ b/src/sgd/frontend/yeastgenome/static/templates/literature_details.jinja2
@@ -69,10 +69,8 @@
         <section id="network" data-magellan-destination="network">
             <h2>Related Literature
                 <a href="#" data-dropdown="network_info"><i class="fa fa-info-circle"></i></a>
-
                 <p id="network_info" class="f-dropdown content medium" data-dropdown-content>
-                    Genes (indicated by gray circles) that share literature with the specified gene (indicated by
-                    yellow circle).
+                    Genes that share literature (indicated by the purple circles) with the specified gene (indicated by yellow circle).
                 </p>
             </h2>
             <hr />
@@ -209,4 +207,3 @@
 <script src="{{asset_root}}/js/cytoscape.js"></script>
 <script src="{{asset_root}}/js/literature_details.js"></script>
 {% endblock scripts %}
-


### PR DESCRIPTION
Redmine issues in this PR
--------------------------
#5614: Preview link points to production
#5667: All qualifiers missing from GAF
#5590: SO Loading script to load the original SO terms into SO table
#5662: GFF dumping script to dump out SO.term_name instead of SO.display_name to gff file
#5680: edits to black toolbar at top of SGD webpages

#5599: Update sequence alignment, Insertion/Deletion and various SNP data for variant viewer
#5604: Load sequence alignment and variant data into database
#5605: Set up web service to retrieve sequence alignment data from database
#4077: Update the SK1 and other alternative strain data/alignments for Variant Viewer

#5663: Logs for curation views
#5384 : new logging for FE and BE
#5688 : Add log to capture sql in sql.log
#5689 : Capture Elastic search queries in es.log file

#5634: Curator Interface locking users from logging into the system (PROD).
#5674: PTM interface unique-key error: won't add new annotation because thinks is duplicate
#5677: Homepage red 'try this' button - change text and linked URL
#5681: Add black bar to the sgd-archive.yeastgenome.org page
#5670: Retire tools in search
——